### PR TITLE
#164139678 Integrate coveralls with readme badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Authors Haven - A Social platform for the creative at heart.
-[![Build Status](https://travis-ci.com/andela/vidar-ah-backend.svg?branch=develop)](https://travis-ci.com/andela/vidar-ah-backend) [![](https://img.shields.io/badge/Protected_by-Hound-a873d1.svg)](https://houndci.com)
+
+[![Build Status](https://travis-ci.com/andela/vidar-ah-backend.svg?branch=develop)](https://travis-ci.com/andela/vidar-ah-backend) [![Coverage Status](https://coveralls.io/repos/github/andela/vidar-ah-backend/badge.svg?branch=master)](https://coveralls.io/github/andela/vidar-ah-backend?branch=master) [![](https://img.shields.io/badge/Protected_by-Hound-a873d1.svg)](https://houndci.com)
 =======
 
 ## Vision

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "coverage": "mocha --reporter mochawesome",
     "db-migrate": "sequelize db:migrate",
     "lint": "eslint routes models config index.js",
-    "test": "mocha --exit"
+    "test": "mocha --exit",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",
@@ -23,16 +24,16 @@
     "jsonwebtoken": "^8.3.0",
     "method-override": "^2.3.10",
     "methods": "^1.1.2",
-    "mongoose": "^5.2.2",
+    "mongoose": "^5.4.16",
     "mongoose-unique-validator": "^2.0.1",
-    "morgan": "^1.9.0",
+    "morgan": "^1.9.1",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "pg": "^7.8.1",
     "request": "^2.87.0",
     "sequelize": "^4.42.1",
-    "slug": "^0.9.1",
-    "underscore": "^1.9.1"
+    "underscore": "^1.9.1",
+    "slug": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -41,6 +42,9 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",
     "mocha": "^6.0.2",
-    "mochawesome": "^3.1.1"
+    "mochawesome": "^3.1.1",
+    "underscore": "^1.9.1",
+    "coveralls": "^3.0.3",
+    "nyc": "^13.3.0"
   }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR integrates coveralls with the repo and adds a readme badge
#### Description of task to be completed?
- Install Coveralls and nyc packages from Npm, include coveralls script in package.json
- Add coveralls badge to the readme file.
#### How should this be manually tested?
Navigate to the readme file on branch `ch-integrate-coveralls-164139678`
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164139678