### PR TITLE
#164603412 Create category for articles

### DIFF
--- a/controllers/category.js
+++ b/controllers/category.js
@@ -1,0 +1,47 @@
+import dotenv from 'dotenv';
+import { Category } from '../models';
+
+dotenv.config();
+
+/**
+ * @class CategoryController
+ *  @override
+ * @export
+ */
+export default class CategoryController {
+  /**
+     * @description - Creates a new category
+     * @static
+     * @param {object} req - HTTP Request
+     * @param {object} res - HTTP Response
+     * @memberof CategoryController
+     * @returns {object} Class instance
+     */
+  static async addNew(req, res) {
+    const {
+      body: {
+        category
+      }
+    } = req;
+    try {
+      const returnValue = await Category.create({ categoryName: category });
+      const { dataValues: { categoryName } } = returnValue;
+      return res.status(201).json({
+        success: true,
+        message: 'Category successfully added.',
+        categoryName
+      });
+    } catch (error) {
+      if (error.errors[0].type === 'unique violation') {
+        return res.status(409).json({
+          success: false,
+          errors: [error.errors[0].message]
+        });
+      }
+      return res.status(500).json({
+        success: false,
+        errors: ['Internal server error']
+      });
+    }
+  }
+}

--- a/doc.json
+++ b/doc.json
@@ -231,6 +231,51 @@
         }
       }
     },
+    "/category": {
+      "post": {
+        "description": "endpoint to create a category",
+        "summary": "adds a new category to the category table",
+        "tags": [
+          "create category"
+        ],
+        "operationId": "CategoryPost",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "x-access-token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/createcategory"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
     "/articles": {
       "post": {
         "tags": [
@@ -343,6 +388,21 @@
           "type": "string"
         }
       }
+    },
+    "createcategory": {
+      "title": "adds a new category to the category table",
+      "example": {
+        "category": "Sport Bulletin"
+      },
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "category"
+      ]
     }
   },
   "externalDocs": {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -17,14 +17,14 @@ class Auth {
     if (!token) {
       return res.status(401).json({
         success: false,
-        message: 'Unauthorized! You are required to be logged in to perform this operation.',
+        errors: ['Unauthorized! You are required to be logged in to perform this operation.'],
       });
     }
     jwt.verify(token, JWT_SECRET, (err, decoded) => {
       if (err) {
         return res.status(401).json({
           success: false,
-          message: 'Your session has expired, please login again to continue',
+          errors: ['Your session has expired, please login again to continue'],
         });
       }
       req.user = decoded;

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -83,3 +83,13 @@ export const validateLogin = [
     .custom(value => !/\s/.test(value))
     .withMessage('Please provide a valid password.'),
 ];
+
+export const validateCategory = [
+  check('category')
+    .exists()
+    .withMessage('No category provided. Please provide a category.')
+    .isLength({ min: 3, max: 30 })
+    .withMessage('Category must be at least 3 characters long and no more than 15.')
+    .isString()
+    .withMessage('Category must be alphanumeric characters, please remove leading and trailing whitespaces.')
+];

--- a/migrations/20190313193812-create-category.js
+++ b/migrations/20190313193812-create-category.js
@@ -1,0 +1,24 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Categories', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    categoryName: {
+      type: Sequelize.STRING,
+      allowNull: false,
+      unique: true
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Categories')
+};

--- a/migrations/20190313195119-add_category_Id_to_article.js
+++ b/migrations/20190313195119-add_category_Id_to_article.js
@@ -1,17 +1,18 @@
 module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.addColumn(
     'Articles',
-    'userId',
+    'categoryId',
     {
       type: Sequelize.INTEGER,
-      allowNull: true
+      allowNull: true,
+      unique: false
     }
   ),
 
   down(queryInterface) {
     return queryInterface.removeColumn(
       'Articles',
-      'userId'
+      'categoryId'
     );
   },
 };

--- a/models/article.js
+++ b/models/article.js
@@ -48,12 +48,18 @@ module.exports = (sequelize, DataTypes) => {
     userId: {
       type: DataTypes.INTEGER,
     },
+    categoryId: {
+      type: DataTypes.INTEGER,
+    }
   }, {});
 
   Article.associate = (models) => {
     Article.belongsTo(models.User, {
       foreignKey: 'userId',
       onDelete: 'CASCADE',
+    });
+    Article.belongsTo(models.Category, {
+      foreignKey: 'categoryId',
     });
   };
   return Article;

--- a/models/category.js
+++ b/models/category.js
@@ -1,0 +1,18 @@
+module.exports = (sequelize, DataTypes) => {
+  const Category = sequelize.define('Category', {
+    categoryName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: {
+        args: true,
+        msg: 'The specified category already exists'
+      }
+    }
+  }, {});
+  Category.associate = (models) => {
+    Category.hasMany(models.Article, {
+      foreignKey: 'id'
+    });
+  };
+  return Category;
+};

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -7,12 +7,14 @@ import addImages from '../middleware/addImage';
 import generateSlug from '../middleware/generateSlug';
 import isUserVerified from '../middleware/verifyUser';
 import ArticleController from '../controllers/articles';
+import CategoryController from '../controllers/category';
 import {
   validateSignup,
   validateLogin,
   validateProfileChange,
   returnValidationErrors,
   validateArticle,
+  validateCategory,
 } from '../middleware/validation';
 
 const { createArticle } = ArticleController;
@@ -75,5 +77,15 @@ apiRoutes.post(
   isUserVerified,
   UserController.loginUser
 );
+
+apiRoutes.route('/category')
+  .post(
+    Auth.verifyUser,
+    isUserVerified,
+    validateCategory,
+    returnValidationErrors,
+    CategoryController.addNew
+  );
+
 
 export default apiRoutes;

--- a/test/article.spec.js
+++ b/test/article.spec.js
@@ -127,10 +127,10 @@ describe('ARTICLES', () => {
         .post('/api/v1/articles')
         .send(article1)
         .end((err, res) => {
-          const { status, body: { message, success } } = res;
+          const { status, body: { errors, success } } = res;
           expect(status).to.be.equal(401);
           expect(success).to.be.equal(false);
-          expect(message).to.be.equal('Unauthorized! You are required to be logged in to perform this operation.');
+          expect(errors[0]).to.be.equal('Unauthorized! You are required to be logged in to perform this operation.');
           done(err);
         });
     });
@@ -144,10 +144,10 @@ describe('ARTICLES', () => {
         .set('authorization', 'asdfghjkl')
         .send(article1)
         .end((err, res) => {
-          const { status, body: { message, success } } = res;
+          const { status, body: { errors, success } } = res;
           expect(status).to.be.equal(401);
           expect(success).to.be.equal(false);
-          expect(message).to.be.equal('Your session has expired, please login again to continue');
+          expect(errors[0]).to.be.equal('Your session has expired, please login again to continue');
           done(err);
         });
     });

--- a/test/category.spec.js
+++ b/test/category.spec.js
@@ -1,0 +1,152 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import updateVerifiedStatus from './helpers/updateVerifiedStatus';
+import app from '../index';
+import {
+  validCategory,
+  invalidCategoryTooShort,
+  invalidCategoryDuplicate,
+} from './helpers/categoryDummyData';
+
+import { newUser2 } from './helpers/userDummyData';
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+
+describe('CREATE CATEGORY', () => {
+  let userToken;
+
+  before((done) => {
+    chai
+      .request(app)
+      .post('/api/v1/user')
+      .send(newUser2)
+      .end((err, res) => {
+        if (!err) {
+          const { body } = res;
+          userToken = body.token;
+        }
+        done();
+      });
+  });
+
+  describe('Make a request without a token', () => {
+    it('It should return a 401 unauthorized error', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/category')
+        .send(validCategory)
+        .end((err, res) => {
+          const { status, body: { success, errors } } = res;
+          expect(status).to.be.equal(401);
+          expect(success).to.be.equal(false);
+          expect(errors[0]).to.be.equal('Unauthorized! You are required to be logged in to perform this operation.');
+          done(err);
+        });
+    });
+  });
+
+  describe('Make a request without verifying your account', () => {
+    it('should return an error status 403', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/category')
+        .set('authorization', userToken)
+        .send(validCategory)
+        .end((err, res) => {
+          const {
+            status,
+            body: { success, errors }
+          } = res;
+          expect(status).to.be.equal(403);
+          expect(success).to.be.equal(false);
+          expect(errors[0]).to.be.equal('User has not been verified.');
+          done(err);
+        });
+    });
+  });
+
+  describe('Make a request with valid and verified credentials', () => {
+    before(() => { updateVerifiedStatus(newUser2.email); });
+    it('should return a success message with status 201', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/category')
+        .set('authorization', userToken)
+        .send(validCategory)
+        .end((err, res) => {
+          const {
+            status,
+            body: { success, message, categoryName }
+          } = res;
+          expect(status).to.be.equal(201);
+          expect(success).to.be.equal(true);
+          expect(message).to.be.equal('Category successfully added.');
+          expect(categoryName).to.be.equal(validCategory.category);
+          done(err);
+        });
+    });
+  });
+
+  describe('Make a request with duplicate category', () => {
+    before(() => { updateVerifiedStatus(newUser2.email); });
+    it('should return a 409 error message', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/category')
+        .set('authorization', userToken)
+        .send(invalidCategoryDuplicate)
+        .end((err, res) => {
+          const {
+            status,
+            body: { success, errors }
+          } = res;
+          expect(status).to.be.equal(409);
+          expect(success).to.be.equal(false);
+          expect(errors[0]).to.be.equal('The specified category already exists');
+          done(err);
+        });
+    });
+  });
+
+  describe('Make a request with category name less than 3 letters', () => {
+    before(() => { updateVerifiedStatus(newUser2.email); });
+    it('should return a 422 error message', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/category')
+        .set('authorization', userToken)
+        .send(invalidCategoryTooShort)
+        .end((err, res) => {
+          const {
+            status,
+            body: { success, errors }
+          } = res;
+          expect(status).to.be.equal(422);
+          expect(success).to.be.equal(false);
+          expect(errors[0]).to.be.equal('Category must be at least 3 characters long and no more than 15.');
+          done(err);
+        });
+    });
+  });
+  describe('Make a request with category not specified', () => {
+    before(() => { updateVerifiedStatus(newUser2.email); });
+    it('should return a 422 error message', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/category')
+        .set('authorization', userToken)
+        .end((err, res) => {
+          const {
+            status,
+            body: { success, errors }
+          } = res;
+          expect(status).to.be.equal(422);
+          expect(success).to.be.equal(false);
+          expect(errors[0]).to.be.equal('No category provided. Please provide a category.');
+          done(err);
+        });
+    });
+  });
+});

--- a/test/helpers/categoryDummyData.js
+++ b/test/helpers/categoryDummyData.js
@@ -1,0 +1,11 @@
+export const validCategory = {
+  category: 'Science and Technology'
+};
+
+export const invalidCategoryTooShort = {
+  category: 'ab'
+};
+
+export const invalidCategoryDuplicate = {
+  category: 'Science and Technology'
+};

--- a/test/helpers/userDummyData.js
+++ b/test/helpers/userDummyData.js
@@ -45,8 +45,27 @@ export const newUser = {
   name: 'testing testing',
   username: 'testing123559'
 };
+export const newUser2 = {
+  email: 'testing2@gmail.com',
+  password: 'testing',
+  name: 'testing testing',
+  username: 'testing223559'
+};
+
+export const newUserVerified = {
+  email: 'testing123559@gmail.com',
+  password: 'testing',
+  name: 'testing testing',
+  username: 'testing223559',
+  verified: true
+};
 
 export const validLoginUser = {
   email: 'testing123559@gmail.com',
+  password: 'testing'
+};
+
+export const unregisteredUser = {
+  email: 'notregistered@gmail.com',
   password: 'testing'
 };

--- a/test/index.js
+++ b/test/index.js
@@ -6,3 +6,4 @@ require('./article.spec');
 require('./profile.spec');
 require('./updateVerifiedStatusHelper.spec');
 require('./login.spec');
+require('./category.spec');

--- a/test/login.spec.js
+++ b/test/login.spec.js
@@ -5,7 +5,7 @@ import faker from 'faker';
 import app from '../index';
 import updateVerifiedStatus from './helpers/updateVerifiedStatus';
 
-import { newUser, validLoginUser } from './helpers/userDummyData';
+import { newUser, validLoginUser, newUserVerified } from './helpers/userDummyData';
 
 // Configure chai
 chai.use(chaiHttp);
@@ -49,7 +49,7 @@ describe('User login authentication: ', () => {
       chai
         .request(app)
         .post('/api/v1/user/login')
-        .send(validLoginUser)
+        .send(newUserVerified)
         .end((err, res) => {
           const {
             status,


### PR DESCRIPTION
#### What does this PR do?
It creates the categories table and implements the endpoint for **creating categories / adding new categories** for the articles

#### Description of Task to be completed?
A registered, verified and logged in user should be able to add new categories to the categories table by hitting the endpoint /category with the request body containing the category name.

#### How should this be manually tested?
- Check .env.sample for the environment variables needed to test the application
- Run `npm run db-migrate` to run migrations
- Run `npm run build` to build the application
- Run `npm start` to start the application
- Make a POST request to `/api/v1/category` with a JSON object containing the field: categoryName. 
- If the `categoryName` is not provided, a 422 error message with be returned.
- Only valid users - registered, and verified can perform this action when they are logged in.
- If this request is successful, you will get a response with status 201, a success message, and the newly created category. 

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164603412

#### Screenshots (if appropriate)
- N/A

#### Questions:
N/A

[Finishes #164603412]