### PR TITLE
164139701 Add reading stats feature

### DIFF
--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -256,6 +256,12 @@ export default class ArticleController {
           attributes: ['username', 'email', 'name', 'bio'],
         }]
       });
+
+      if (req.user) {
+        const { id } = req.user;
+        const viewer = await User.findOne({ where: { id } });
+        await viewer.addView(article);
+      }
       return res.status(200).json({
         success: true,
         article: article.dataValues

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -222,4 +222,27 @@ export default class UserController {
       message: 'Password changed successfully.'
     });
   }
+
+  /**
+ * @description Get user reading stats
+ * @param {object} req http request object
+ * @param {object} res http response object
+ * @returns {object} response
+ */
+  static async getReadingStats(req, res) {
+    const { id } = req.user;
+    const user = await User.findOne({ where: { id } });
+    try {
+      const viewCount = await user.getView();
+      return res.status(200).json({
+        success: true,
+        message: viewCount.length
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        errors: [error.message]
+      });
+    }
+  }
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -5,13 +5,13 @@ const { JWT_SECRET } = process.env;
 * Authentication class
 */
 class Auth {
-/**
-  * @description Middleware function to verify if user has a valid token
-  * @param {object} req http request object
-  * @param {object} res http response object
-  * @param {Function} next next middleware function
-  * @returns {undefined}
-*/
+  /**
+    * @description Middleware function to verify if user has a valid token
+    * @param {object} req http request object
+    * @param {object} res http response object
+    * @param {Function} next next middleware function
+    * @returns {undefined}
+  */
   static verifyUser(req, res, next) {
     const token = req.headers['x-access-token'] || req.query.token || req.headers.authorization;
     if (!token) {
@@ -19,6 +19,30 @@ class Auth {
         success: false,
         errors: ['Unauthorized! You are required to be logged in to perform this operation.'],
       });
+    }
+    jwt.verify(token, JWT_SECRET, (err, decoded) => {
+      if (err) {
+        return res.status(401).json({
+          success: false,
+          errors: ['Your session has expired, please login again to continue'],
+        });
+      }
+      req.user = decoded;
+      return next();
+    });
+  }
+
+  /**
+    * @description Middleware function to verify if user isLogged in
+    * @param {object} req http request object
+    * @param {object} res http response object
+    * @param {Function} next next middleware function
+    * @returns {undefined}
+  */
+  static isLoggedIn(req, res, next) {
+    const token = req.headers['x-access-token'] || req.query.token || req.headers.authorization;
+    if (!token) {
+      return next();
     }
     jwt.verify(token, JWT_SECRET, (err, decoded) => {
       if (err) {

--- a/migrations/20190320101322-create-stats.js
+++ b/migrations/20190320101322-create-stats.js
@@ -1,0 +1,27 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('stats', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      type: Sequelize.INTEGER
+    },
+    articleId: {
+      type: Sequelize.UUID
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down(queryInterface) {
+    return queryInterface.dropTable('stats');
+  }
+};

--- a/models/User.js
+++ b/models/User.js
@@ -77,8 +77,12 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'userId',
       onDelete: 'CASCADE'
     });
+    User.belongsToMany(models.Article, {
+      foreignKey: 'userId',
+      as: 'view',
+      through: models.stats
+    });
   };
-
 
   User.hook('beforeValidate', (user) => {
     user.verificationId = shortId.generate();

--- a/models/article.js
+++ b/models/article.js
@@ -69,6 +69,11 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'articleId',
       onDelete: 'CASCADE'
     });
+    Article.belongsToMany(models.User, {
+      foreignKey: 'articleId',
+      as: 'viewers',
+      through: models.stats
+    });
   };
   return Article;
 };

--- a/models/stats.js
+++ b/models/stats.js
@@ -1,0 +1,7 @@
+module.exports = (sequelize, DataTypes) => {
+  const stats = sequelize.define('stats', {
+    userId: DataTypes.INTEGER,
+    articleId: DataTypes.UUID
+  }, {});
+  return stats;
+};

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -155,6 +155,7 @@ apiRoutes.get(
 
 apiRoutes.get(
   '/articles/:slug',
+  Auth.isLoggedIn,
   ArticleController.getArticleBySlug,
 );
 
@@ -204,5 +205,10 @@ apiRoutes.route('/articles/:slug/comments/:id')
     CommentController.deleteComment
   );
 
+apiRoutes.get(
+  '/user/readingstats',
+  Auth.verifyUser,
+  UserController.getReadingStats
+);
 
 export default apiRoutes;

--- a/test/helpers/dummyData.js
+++ b/test/helpers/dummyData.js
@@ -17,3 +17,9 @@ export const article1 = {
   description: 'This is the description of the test article',
   body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
 };
+
+export const statArticle = {
+  title: 'This is the stat article',
+  description: 'This is the description of the stat article',
+  body: 'Stat ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+};

--- a/test/helpers/userDummyData.js
+++ b/test/helpers/userDummyData.js
@@ -125,3 +125,11 @@ export const validUser4 = {
   password: 'validUser4',
   username: 'validuser4'
 };
+
+export const validStatUser = {
+  username: 'validstatuser',
+  email: 'jessamstat@gmail.com',
+  name: 'Flipping James',
+  password: 'abcdef',
+  verified: true
+};

--- a/test/index.js
+++ b/test/index.js
@@ -9,3 +9,4 @@ import './resetpassword.spec';
 import './category.spec';
 import './follow.spec';
 import './rating.spec';
+import './stats.spec';

--- a/test/login.spec.js
+++ b/test/login.spec.js
@@ -41,8 +41,8 @@ describe('User login authentication: ', () => {
   });
 
   describe('Make a request with valid credentials', () => {
-    before(() => {
-      updateVerifiedStatus(validLoginUser.email);
+    before(async () => {
+      await updateVerifiedStatus(validLoginUser.email);
     });
     it('should return a success message with status 200', (done) => {
       chai

--- a/test/stats.spec.js
+++ b/test/stats.spec.js
@@ -1,0 +1,90 @@
+import dotenv from 'dotenv';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import { validStatUser } from './helpers/userDummyData';
+import updateVerifiedStatus from './helpers/updateVerifiedStatus';
+import { statArticle } from './helpers/dummyData';
+
+dotenv.config();
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+let userToken;
+let articleSlug;
+
+describe('Make a request to signup with valid details', () => {
+  it('Returns a successful message', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/user/signup')
+      .send(validStatUser)
+      .end((err, res) => {
+        const { status, body: { message, success, token } } = res;
+        expect(status).to.be.equal(201);
+        expect(success).to.be.equal(true);
+        expect(message).to.be.equal('You have signed up successfully.');
+        userToken = token;
+        done(err);
+      });
+  });
+});
+
+describe('Create an article by an authenticated and verified user', () => {
+  before(() => { updateVerifiedStatus(validStatUser.email); });
+  it('should create a new article.', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/articles')
+      .set('authorization', userToken)
+      .send(statArticle)
+      .end((err, res) => {
+        const { status, body: { message, success, article: { slug } } } = res;
+        articleSlug = slug;
+        expect(status).to.be.equal(201);
+        expect(success).to.be.equal(true);
+        expect(message).to.be.equal('New article created successfully');
+        done(err);
+      });
+  });
+});
+
+describe('View an article', () => {
+  it('Should should return an array of results', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/articles/${articleSlug}`)
+      .set('x-access-token', userToken)
+      .end((err, res) => {
+        const { status, body: { success, article } } = res;
+        expect(status).to.be.equal(200);
+        expect(success).to.be.equal(true);
+        expect(article).to.be.an('object');
+        expect(article).to.haveOwnProperty('id');
+        expect(article).to.haveOwnProperty('slug');
+        expect(article).to.haveOwnProperty('title');
+        expect(article).to.haveOwnProperty('body');
+        expect(article).to.haveOwnProperty('description');
+        expect(article).to.haveOwnProperty('author');
+        done(err);
+      });
+  });
+});
+
+describe('View an article', () => {
+  it('Should should a number', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/user/readingstats')
+      .set('x-access-token', userToken)
+      .end((err, res) => {
+        const { status, body: { success, message } } = res;
+        expect(status).to.be.equal(200);
+        expect(success).to.be.equal(true);
+        expect(message).to.be.a('number');
+        expect(message).to.be.equal(1);
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
This PR adds a feature to allow a user see their reading stats
#### Description of task to be completed?
* Add endpoint that returns the total number of articles a user has read
#### How can this be manually tested?
* Create two user accounts
* Use the first account to create some articles
* Use the second account to get those articles by their slugs
* Send a get request to `GET /api/v1/user/readingstats` with a valid token belonging to the second user
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164139701
 