### PR TITLE
#164825605 Change reading stats endpoint response

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -236,7 +236,7 @@ export default class UserController {
       const viewCount = await user.getView();
       return res.status(200).json({
         success: true,
-        message: viewCount.length
+        numberOfArticlesRead: viewCount.length
       });
     } catch (error) {
       return res.status(500).json({

--- a/test/stats.spec.js
+++ b/test/stats.spec.js
@@ -79,11 +79,11 @@ describe('View an article', () => {
       .get('/api/v1/user/readingstats')
       .set('x-access-token', userToken)
       .end((err, res) => {
-        const { status, body: { success, message } } = res;
+        const { status, body: { success, numberOfArticlesRead } } = res;
         expect(status).to.be.equal(200);
         expect(success).to.be.equal(true);
-        expect(message).to.be.a('number');
-        expect(message).to.be.equal(1);
+        expect(numberOfArticlesRead).to.be.a('number');
+        expect(numberOfArticlesRead).to.be.equal(1);
         done(err);
       });
   });


### PR DESCRIPTION
#### What does this PR do?
This PR changes the response of the reading stats endpoint
#### Description of task to be completed?
* Change the response of the reading stats endpoint from `message` to `numberOfArticlesRead`
#### Hoe should this be  manually tested?
* Send a `GET` request to `/api/v1/user/readingstats` with a valid user token
#### What are the relevant pivotal tracker links?
https://www.pivotaltracker.com/story/show/164825605
