### PR TITLE
#165410830 Return reaction count along with an article

### DIFF
--- a/models/article.js
+++ b/models/article.js
@@ -65,6 +65,8 @@ module.exports = (sequelize, DataTypes) => {
     });
     Article.hasMany(models.Reaction, {
       foreignKey: 'articleSlug',
+      as: 'articleReactions',
+      sourceKey: 'slug'
     });
     Article.hasMany(models.Comment, {
       foreignKey: 'articleSlug',


### PR DESCRIPTION
#### What does this PR do?
This PR returns the reaction count along with an article
#### Description of task to be completed?
* Add like count to article response body
* Add dislike count to article response body
* Show if user has already reacted to an article
#### Any background context you would love to provide?
Users can get article whether they're logged in or not. Articles should return the number of a reactions and whether a user has reacted to the article or not.
#### How can this be manually tested?
Send a get request to `api/v1/articles/:slug`
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/165410830