### PR TITLE
#165596222 Remove payload from url params to request body

### DIFF
--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -205,7 +205,7 @@ export default class ArticleController {
   static async likeArticle(req, res) {
     try {
       const { id: userId } = req.user;
-      const { slug: articleSlug } = req.params;
+      const { slug: articleSlug } = req.body;
       const getArticles = await Article.findOne({
         where: {
           slug: articleSlug
@@ -245,7 +245,7 @@ export default class ArticleController {
   static async dislikeArticle(req, res) {
     try {
       const { id: userId } = req.user;
-      const { slug: articleSlug } = req.params;
+      const { slug: articleSlug } = req.body;
       const getArticles = await Article.findOne({
         where: {
           slug: articleSlug

--- a/middleware/follow.js
+++ b/middleware/follow.js
@@ -1,7 +1,7 @@
 import { User } from '../models';
 
 export default async (req, res, next) => {
-  const userToFollowId = req.params.id;
+  const userToFollowId = req.body.id;
   const { id } = req.user;
 
   // Return an error if a user tries to follow their account

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -144,9 +144,7 @@ export const validatePassword = [
 ];
 
 export const checkIfArticleExists = async (req, res, next) => {
-  const {
-    params: { slug }
-  } = req;
+  const slug = (req.params.slug) ? req.params.slug : req.body.slug;
   try {
     const article = await Article.findOne({
       where: {

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -216,7 +216,7 @@ apiRoutes.post(
 );
 
 apiRoutes.post(
-  '/like_article/:slug',
+  '/like_article',
   Auth.verifyUser,
   isUserVerified,
   checkIfArticleExists,
@@ -224,7 +224,7 @@ apiRoutes.post(
 );
 
 apiRoutes.post(
-  '/dislike_article/:slug',
+  '/dislike_article',
   Auth.verifyUser,
   isUserVerified,
   checkIfArticleExists,
@@ -244,14 +244,14 @@ apiRoutes.get(
 );
 
 apiRoutes.post(
-  '/follow/:id',
+  '/follow',
   Auth.verifyUser,
   followVerification,
   followUser
 );
 
 apiRoutes.post(
-  '/unfollow/:id',
+  '/unfollow',
   Auth.verifyUser,
   followVerification,
   unfollowUser

--- a/test/article.spec.js
+++ b/test/article.spec.js
@@ -642,8 +642,9 @@ describe('/POST articles like', () => {
   it('should return an error if the article is not found', (done) => {
     chai
       .request(app)
-      .post('/api/v1/like_article/article-writing-b4ngik')
+      .post('/api/v1/like_article')
       .set('authorization', userToken2)
+      .send({ slug: 'article-writingd-b4nfgik' })
       .end((err, res) => {
         expect(res).to.have.status(404);
         expect(res.body).to.have.property('success').equal(false);
@@ -655,8 +656,9 @@ describe('/POST articles like', () => {
   it('should create an article like reaction', (done) => {
     chai
       .request(app)
-      .post(`/api/v1/like_article/${articleSlug2}`)
+      .post('/api/v1/like_article')
       .set('authorization', userToken2)
+      .send({ slug: articleSlug2 })
       .end((err, res) => {
         reaction = res.body.reaction;
         expect(res).to.have.status(201);
@@ -669,8 +671,9 @@ describe('/POST articles like', () => {
   it('should create an article like reaction', (done) => {
     chai
       .request(app)
-      .post(`/api/v1/like_article/${articleSlug3}`)
+      .post('/api/v1/like_article')
       .set('authorization', userToken2)
+      .send({ slug: articleSlug3 })
       .end((err, res) => {
         reaction = res.body.reaction;
         expect(res).to.have.status(201);
@@ -683,8 +686,9 @@ describe('/POST articles like', () => {
   it('should unlike an article reaction if the article has been liked', (done) => {
     chai
       .request(app)
-      .post(`/api/v1/like_article/${articleSlug2}`)
+      .post('/api/v1/like_article')
       .set('authorization', userToken2)
+      .send({ slug: articleSlug2 })
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body).to.have.property('success').equal(true);
@@ -731,8 +735,9 @@ describe('/POST articles dislike', () => {
   it('should create an article dislike reaction', (done) => {
     chai
       .request(app)
-      .post(`/api/v1/dislike_article/${articleSlug2}`)
+      .post('/api/v1/dislike_article')
       .set('authorization', userToken2)
+      .send({ slug: articleSlug2 })
       .end((err, res) => {
         reaction = res.body.reaction;
         expect(res).to.have.status(201);
@@ -745,8 +750,9 @@ describe('/POST articles dislike', () => {
   it('should remove an article reaction if the article has been disliked', (done) => {
     chai
       .request(app)
-      .post(`/api/v1/dislike_article/${articleSlug2}`)
+      .post('/api/v1/dislike_article')
       .set('authorization', userToken2)
+      .send({ slug: articleSlug2 })
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body).to.have.property('success').equal(true);
@@ -788,6 +794,22 @@ describe('/POST articles dislike', () => {
         expect(res.body).to.have.property('success').equal(false);
         expect(res.body).to.have.property('errors');
         expect(res.body.errors[0]).equal('Your session has expired, please login again to continue');
+        done(err);
+      });
+  });
+});
+describe('Make a request with an invalid token', () => {
+  it('should return session expired', (done) => {
+    const invalidToken = `${userToken2}111`;
+    chai
+      .request(app)
+      .get(`/api/v1/articles/${articleSlug2}`)
+      .set('Authorization', invalidToken)
+      .end((err, res) => {
+        const { status, body: { success, errors } } = res;
+        expect(status).to.be.equal(401);
+        expect(success).to.be.equal(false);
+        expect(errors[0]).to.be.equal('Your session has expired, please login again to continue');
         done(err);
       });
   });

--- a/test/follow.spec.js
+++ b/test/follow.spec.js
@@ -58,8 +58,9 @@ describe('Make a request to follow a non existing user', () => {
   it('Returns an error message.', (done) => {
     chai
       .request(app)
-      .post('/api/v1/follow/1111')
+      .post('/api/v1/follow')
       .set('x-access-token', userToken)
+      .send({ id: 1111 })
       .end((err, res) => {
         const { status, body: { errors, success } } = res;
         expect(status).to.be.equal(404);
@@ -74,11 +75,12 @@ describe('Make a request to follow a non existing user', () => {
 describe('Make a request to follow a non verified user', () => {
   it('Returns an error message.', async () => {
     userId2 = await getId(validFollowUser2.email);
-    const url = `/api/v1/follow/${userId2}`;
+    const url = '/api/v1/follow/';
     chai
       .request(app)
       .post(url)
       .set('x-access-token', userToken)
+      .send({ id: userId2 })
       .end((err, res) => {
         const { status, body: { errors, success } } = res;
         expect(status).to.be.equal(404);
@@ -92,11 +94,12 @@ describe('Make a request to follow a non verified user', () => {
 describe('Make a request to follow self', () => {
   it('Returns an error message.', async () => {
     const userId = await getId(validFollowUser.email);
-    const url = `/api/v1/follow/${userId}`;
+    const url = '/api/v1/follow/';
     chai
       .request(app)
       .post(url)
       .set('x-access-token', userToken)
+      .send({ id: userId })
       .end((err, res) => {
         const { status, body: { errors, success } } = res;
         expect(status).to.be.equal(403);
@@ -110,11 +113,12 @@ describe('Make a request to follow self', () => {
 describe('Make a request to unfollow another user not currently being followed', () => {
   before(() => updateVerifiedStatus(validFollowUser2.email));
   it('Returns an error message.', (done) => {
-    const url = `/api/v1/unfollow/${userId2}`;
+    const url = '/api/v1/unfollow/';
     chai
       .request(app)
       .post(url)
       .set('x-access-token', userToken)
+      .send({ id: userId2 })
       .end((err, res) => {
         const { status, body: { errors, success } } = res;
         expect(status).to.be.equal(403);
@@ -128,11 +132,12 @@ describe('Make a request to unfollow another user not currently being followed',
 
 describe('Make a valid request to follow another user', () => {
   it('Returns a success message.', (done) => {
-    const url = `/api/v1/follow/${userId2}`;
+    const url = '/api/v1/follow/';
     chai
       .request(app)
       .post(url)
       .set('x-access-token', userToken)
+      .send({ id: userId2 })
       .end((err, res) => {
         const { status, body: { message, success } } = res;
         expect(status).to.be.equal(201);
@@ -145,11 +150,12 @@ describe('Make a valid request to follow another user', () => {
 
 describe('Make a request to follow another user again', () => {
   it('Returns an error message.', (done) => {
-    const url = `/api/v1/follow/${userId2}`;
+    const url = '/api/v1/follow/';
     chai
       .request(app)
       .post(url)
       .set('x-access-token', userToken)
+      .send({ id: userId2 })
       .end((err, res) => {
         const { status, body: { errors, success } } = res;
         expect(status).to.be.equal(403);
@@ -163,11 +169,12 @@ describe('Make a request to follow another user again', () => {
 
 describe('Make a valid request to unfollow another user', () => {
   it('Returns a success message.', (done) => {
-    const url = `/api/v1/unfollow/${userId2}`;
+    const url = '/api/v1/unfollow/';
     chai
       .request(app)
       .post(url)
       .set('x-access-token', userToken)
+      .send({ id: userId2 })
       .end((err, res) => {
         const { status, body: { message, success } } = res;
         expect(status).to.be.equal(200);

--- a/test/user.spec.js
+++ b/test/user.spec.js
@@ -252,3 +252,19 @@ describe('Make a request to get the article count of a user', () => {
       });
   });
 });
+describe('Make a request with an invalid token', () => {
+  it('should return session expired', (done) => {
+    const invalidToken = `${userToken}111`;
+    chai
+      .request(app)
+      .get('/api/v1/user/articlescount')
+      .set('Authorization', invalidToken)
+      .end((err, res) => {
+        const { status, body: { success, errors } } = res;
+        expect(status).to.be.equal(401);
+        expect(success).to.be.equal(false);
+        expect(errors[0]).to.be.equal('Your session has expired, please login again to continue');
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
This PR removes payload from url params and adds them to the request body
#### Description of task to be completed?
* Remove slug from params and add to request body in like article route
* Remove slug from params and add to request body in unlike article route
* Remove id from params and add to request body in follow route
* Remove id from params and add to request body in unfollow route
#### How can this be manually tested?
* Send a post request to `api/v1/like_article` with `{ slug: 'articleSlug' }` as the request body
* Send a post request to `api/v1/dislike_article` with `{ slug: 'articleSlug' }` as the request body
* Send a post request to `api/v1/follow` with `{ id: userid }` as the request body
* Send a post request to `api/v1/unfollow` with `{ id: userid }` as the request body
#### Any background context you would love to provide?
N/A
#### Screenshots (if applicable)
N/A
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/165596222